### PR TITLE
Limit Cassandra memory to 1G

### DIFF
--- a/deploy/local/docker-compose.yaml
+++ b/deploy/local/docker-compose.yaml
@@ -6,11 +6,18 @@ services:
     environment:
       JVM_OPTS: -Dcassandra.skip_wait_for_gossip_to_settle=0
       CASSANDRA_CLUSTER_NAME: terec
+      MAX_HEAP_SIZE: 512M
+      HEAP_NEW_SIZE: 64M
     healthcheck:
       test: ["CMD", "cqlsh", "127.0.0.1", "-e", "SHOW VERSION;"]
-      interval: 10s
+      interval: 30s
       timeout: 10s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "1024M"
   terec-api:
     image: "terec/api:latest"
     ports:
@@ -21,3 +28,8 @@ services:
     environment:
       CASSANDRA_HOSTS: terec-cassandra
       CASSANDRA_KEYSPACE: terec
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "256M"

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,10 +1,12 @@
-version: '3'
+version: "3"
 services:
   cassandra:
     image: "cassandra:5.0.3"
     environment:
       - JVM_OPTS=-Dcassandra.skip_wait_for_gossip_to_settle=0
       - CASSANDRA_CLUSTER_NAME=terec_test
+      - MAX_HEAP_SIZE=512M
+      - HEAP_NEW_SIZE=512M
     ports:
       - "9042:9042"
     healthcheck:
@@ -12,3 +14,8 @@ services:
       interval: 60s
       timeout: 10s
       retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "1024MB"


### PR DESCRIPTION
Rationale:
limit memory required for test run and basic local deployment.