### PR TITLE
feat: add AstraDB connectivity

### DIFF
--- a/components/terec/database/core.py
+++ b/components/terec/database/core.py
@@ -1,14 +1,21 @@
 """
 Keep connection parameters in the env variables
 as this will make it easy to pass to docker or use in testing.
-TODO: shall we support connecting to Astra DB (requires secure bundle)
 TODO: maybe we will have to add some case class CassandraConfig and pass it
 """
 
 import os
 
-from cassandra.cluster import Cluster, Session
-from cassandra.auth import DSEPlainTextAuthProvider
+from cassandra.cluster import (
+    Cluster,
+    Session,
+    ExecutionProfile,
+    EXEC_PROFILE_DEFAULT,
+    ProtocolVersion,
+)
+from cassandra.auth import DSEPlainTextAuthProvider, PlainTextAuthProvider
+from loguru import logger
+
 
 CASSANDRA_HOSTS = os.getenv("CASSANDRA_HOSTS", None)
 CASSANDRA_PORT = os.getenv("CASSANDRA_PORT", None)
@@ -17,7 +24,33 @@ CASSANDRA_PASSWORD = os.getenv("CASSANDRA_PASS", None)
 CASSANDRA_KEYSPACE = os.getenv("CASSANDRA_KEYSPACE", "terec")
 
 
-def cassandra_cluster() -> Cluster:
+ASTRADB_SCB_PATH = os.getenv("ASTRADB_SCB_PATH", None)
+ASTRADB_TOKEN = os.getenv("ASTRADB_TOKEN", None)
+
+
+def cassandra_session(drop_keyspace: bool = False) -> Session:
+    """
+    Return connection to the database with keyspace created if not exists
+    TODO: keyspace management should be moved outside
+    """
+    if _is_astradb():
+        logger.info("Connecting to Astra DB using {}", ASTRADB_SCB_PATH)
+        session = _astradb_cluster().connect()
+    else:
+        logger.info("Connecting to Cassandra using {}", CASSANDRA_HOSTS)
+        session = _cassandra_cluster().connect()
+        _prepare_keyspace(session, drop_keyspace)
+
+    logger.info("Connected using keyspace {}", CASSANDRA_KEYSPACE)
+    session.set_keyspace(CASSANDRA_KEYSPACE)
+    return session
+
+
+def _is_astradb():
+    return ASTRADB_SCB_PATH is not None and ASTRADB_SCB_PATH != ""
+
+
+def _cassandra_cluster() -> Cluster:
     options = {"protocol_version": 5}
     if CASSANDRA_HOSTS:
         options["contact_points"] = CASSANDRA_HOSTS.split(",")
@@ -34,20 +67,31 @@ def cassandra_cluster() -> Cluster:
     return Cluster(**options)
 
 
-def cassandra_session(drop_keyspace: bool = False) -> Session:
+def _astradb_cluster() -> Cluster:
     """
-    Return connection to the database with keyspace created if not exists
-    TODO: keyspace management should be moved outside
+    Makes connection to Astra DB.
+    https://docs.datastax.com/en/astra-db-serverless/databases/python-driver.html
     """
-    session = cassandra_cluster().connect()
+    assert ASTRADB_SCB_PATH, "ASTRADB_SCB_PATH is not set"
+    assert ASTRADB_TOKEN, "ASTRADB_TOKEN is not set"
+    cloud_config = {"secure_connect_bundle": ASTRADB_SCB_PATH, "connect_timeout": 30}
+    auth_provider = PlainTextAuthProvider("token", ASTRADB_TOKEN)
+    profile = ExecutionProfile(request_timeout=30)
+    return Cluster(
+        cloud=cloud_config,
+        auth_provider=auth_provider,
+        execution_profiles={EXEC_PROFILE_DEFAULT: profile},
+        protocol_version=ProtocolVersion.V4,
+    )
+
+
+def _prepare_keyspace(session, drop_keyspace: bool = False) -> None:
     if drop_keyspace:
         session.execute(f"DROP KEYSPACE IF EXISTS {CASSANDRA_KEYSPACE};")
+
     replication_strategy = {
         "class": "SimpleStrategy",
         "replication_factor": 1,  # Adjust replication factor as needed
     }
-    # Create the keyspace if it doesn't exist
     query = f"CREATE KEYSPACE IF NOT EXISTS {CASSANDRA_KEYSPACE} WITH replication = {str(replication_strategy)}"
     session.execute(query)
-    session.set_keyspace(CASSANDRA_KEYSPACE)
-    return session

--- a/deploy/astradb/docker-compose.yaml
+++ b/deploy/astradb/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  terec-api:
+    image: "terec/api:latest"
+    ports:
+      - "8000:8000"
+    environment:
+      ASTRADB_TOKEN: ${ASTRADB_TOKEN}
+      ASTRADB_SCB_PATH: /app/secure_connect_bundle.zip
+    volumes:
+      - "${ASTRADB_SCB_PATH}:/app/secure_connect_bundle.zip:ro"
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "256M"

--- a/development/connect-astradb.py
+++ b/development/connect-astradb.py
@@ -1,0 +1,6 @@
+from terec.database import cassandra_session
+from terec.model.util import cqlengine_init
+
+# initialize cassandra connection
+cassandra = cassandra_session()
+cqlengine_init(cassandra)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,17 @@ popd
 """
 interpreter = "bash"
 
-[tool.poe.tasks.start-docker]
+[tool.poe.tasks.start-local]
 shell = "docker compose --project-directory deploy/local/ up"
+
+[tool.poe.tasks.stop-local]
+shell = "docker compose --project-directory deploy/local/ down"
+
+[tool.poe.tasks.start-astradb]
+shell = "docker compose --project-directory deploy/astradb/ up"
+
+[tool.poe.tasks.stop-astradb]
+shell = "docker compose --project-directory deploy/astradb/ down"
 
 [tool.poe.tasks.start-api]
 shell = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,13 +82,13 @@ popd
 interpreter = "bash"
 
 [tool.poe.tasks.start-local]
-shell = "docker compose --project-directory deploy/local/ up"
+shell = "docker compose --project-directory deploy/local/ up --detach"
 
 [tool.poe.tasks.stop-local]
 shell = "docker compose --project-directory deploy/local/ down"
 
 [tool.poe.tasks.start-astradb]
-shell = "docker compose --project-directory deploy/astradb/ up"
+shell = "docker compose --project-directory deploy/astradb/ up --detach"
 
 [tool.poe.tasks.stop-astradb]
 shell = "docker compose --project-directory deploy/astradb/ down"


### PR DESCRIPTION
Before this change the only supported database was Apache Cassandra (or DSE) configured via CASSANDRA_xxx env variables.

This change adds AstraDB as supported database (as it is Cassandra compatible). It is configured through two env variables:
ASTRADB_SCB_PATH - secure bundle zip to allow connection ASTRADB_TOKEN - token for auth/authz

Notes on preparation:
- token needs to be Database Administator level
- I have used "astra" cli to download secure connection bundle
- keyspaces are to be created via AstraDB panel (not via cql!!)

Notes:
1. when AstraDB connection is used keyspace is not created (and not droped).
2. making connection takes 5s
3. poe test passed (sic!)