### PR TITLE
Support TEREC_API_KEY env variable in cli {builds, tests}

### DIFF
--- a/bases/terec/cli/builds_commands.py
+++ b/bases/terec/cli/builds_commands.py
@@ -15,10 +15,10 @@ def get_builds(org: str, project: str, suite: str, branch: str):
     return get_terec_rest_api(url, query_params)
 
 
-def get_build(terec, suite: str, run_id: int):
+def get_build(terec, suite: str, branch: str, run_id: int):
     from terec.util.cli_util import get_terec_rest_api, TerecCallContext
 
-    url = f"{terec.url}/tests/orgs/{terec.org}/projects/{terec.prj}/suites/{suite}/runs/{run_id}"
+    url = f"{terec.url}/tests/orgs/{terec.org}/projects/{terec.prj}/suites/{suite}/branches/{branch}/runs/{run_id}"
     return get_terec_rest_api(url, {})
 
 
@@ -109,6 +109,7 @@ def history(
 @builds_app.command()
 def show(
     suite: str = params.ARG_SUITE,
+    branch: str = params.ARG_BRANCH,
     run_id: int = params.ARG_RUN_ID,
     org: str = params.OPT_ORG,
     project: str = params.OPT_PRJ,
@@ -120,7 +121,7 @@ def show(
     from terec.util.cli_util import TerecCallContext
 
     terec = TerecCallContext.create(org, project)
-    data = get_build(terec, suite, run_id)
+    data = get_build(terec, suite, branch, run_id)
     pprint(data)
 
 
@@ -186,6 +187,7 @@ def bar(
     """
     import plotext as plt
 
+    typer.echo(f"Using field: {field} for bar size.")
     data = get_builds(org, project, suite, branch)
     usable_data = [b for b in data if b[field] is not None]
     unusable_data = [b for b in data if b[field] is None]

--- a/bases/terec/cli/main.py
+++ b/bases/terec/cli/main.py
@@ -8,10 +8,24 @@ from terec.cli.jenkins_commands import jenkins_app
 app = typer.Typer()
 
 # Add existing command groups
-app.add_typer(builds_app, name="builds")
-app.add_typer(tests_app, name="tests")
+app.add_typer(
+    builds_app, name="builds", short_help="Commands on builds (suite runs) history."
+)
+app.add_typer(tests_app, name="tests", short_help="Commands on test cases history.")
 app.add_typer(junit_app, name="junit")
-app.add_typer(jenkins_app, name="jenkins")
+app.add_typer(
+    jenkins_app, name="jenkins", short_help="Export Jenkins CI builds and test reports."
+)
+
+
+@app.command(short_help="Prints common env variables to be set when using cli.")
+def env():
+    typer.echo("Common env variables:")
+    typer.echo("TEREC_URL - for the TeReC api url.")
+    typer.echo("TEREC_API_KEY - api key for private orgs.")
+    typer.echo("TEREC_ORG - org name (instead of --org)")
+    typer.echo("TEREC_PROJECT - project name (instead of --project)")
+
 
 # Entry point
 if __name__ == "__main__":

--- a/bases/terec/util/cli_params.py
+++ b/bases/terec/util/cli_params.py
@@ -39,8 +39,6 @@ BUILD_FIELDS = [
     "duration_sec",
 ]
 
-ARG_BUILD_FIELD = (
-    typer.Option("fail_count", help=f"field to use from {BUILD_FIELDS}"),
-)
+ARG_BUILD_FIELD = typer.Option("fail_count", help=f"field to use from {BUILD_FIELDS}")
 
 OPT_PROGRESS: bool = typer.Option(False, help="show progress in stderr")

--- a/bases/terec/util/cli_util.py
+++ b/bases/terec/util/cli_util.py
@@ -7,6 +7,8 @@ import aiohttp
 import asyncio
 from urllib.parse import urlparse
 
+from terec.api.auth import api_key_headers
+
 
 def not_none(v: str, msg: str) -> str:
     if not v:
@@ -30,7 +32,8 @@ def value_or_env(val: str, env_var: str) -> str:
 def get_terec_rest_api(url: str, query_params: dict):
     import requests
 
-    resp = requests.get(url=url, params=query_params)
+    api_key = os.environ.get("TEREC_API_KEY")
+    resp = requests.get(url=url, params=query_params, headers=api_key_headers(api_key))
     if resp.ok:
         return resp.json()
     else:


### PR DESCRIPTION
This change:
- generic support for TEREC_API_KEY
- fix some cli commands
- add env command to print common env variables