### PR TITLE
Create app only once in fixture

### DIFF
--- a/test/bases/terec/api/test_benchmark_results_api.py
+++ b/test/bases/terec/api/test_benchmark_results_api.py
@@ -1,13 +1,12 @@
 import json
+import pytest
 
 from faker import Faker
 from fastapi.encoders import jsonable_encoder
-from fastapi.testclient import TestClient
 from pytest import fixture
 
 from assertions import raise_for_status
 from .random_data import random_test_case_run_info
-from terec.api.core import create_app
 
 
 @fixture(scope="module")
@@ -15,10 +14,9 @@ def random_100_test_runs():
     return [random_test_case_run_info() for _ in range(100)]
 
 
+@pytest.mark.usefixtures("api_client")
 class TestBenchmarkResultsAPI:
     fake = Faker()
-    api_app = create_app()
-    api_client = TestClient(app=api_app)
 
     def post_test_results(
         self, org: str, prj: str, suite: str, branch: str, run: int, body: str

--- a/test/bases/terec/api/test_core.py
+++ b/test/bases/terec/api/test_core.py
@@ -1,11 +1,3 @@
-from fastapi.testclient import TestClient
-
-from terec.api.core import create_app
-
-
-def test_openapi_doc(cassandra_model):
-    api_app = create_app()
-    assert api_app is not None
-    api_client = TestClient(app=api_app)
+def test_openapi_doc(cassandra_model, api_client):
     response = api_client.get("docs")
     assert response.is_success, response.text

--- a/test/bases/terec/api/test_failures_api.py
+++ b/test/bases/terec/api/test_failures_api.py
@@ -1,17 +1,18 @@
 import pytest
 from faker import Faker
-from fastapi.testclient import TestClient
 
 from generator import ResultsGenerator, generate_suite_with_test_runs
 from conftest import random_name
-from terec.api.core import create_app
 from terec.model.results import TestCaseRun
 
 
+@pytest.mark.usefixtures("api_client")
 class TestFailuresGetFailedTestsAPI:
     fake = Faker()
-    api_app = create_app()
-    api_client = TestClient(api_app)
+
+    @pytest.fixture(autouse=True)
+    def inject_client(self, api_client):
+        self.api_client = api_client
 
     def get_failed_tests(self, org, project, suite, branch, headers=None):
         url = f"/history/orgs/{org}/projects/{project}/suites/{suite}/failed-tests"
@@ -61,10 +62,13 @@ class TestFailuresGetFailedTestsAPI:
         assert resp.status_code == 401
 
 
+@pytest.mark.usefixtures("api_client")
 class TestFailuresGetTestRunsAPI:
     fake = Faker()
-    api_app = create_app()
-    api_client = TestClient(api_app)
+
+    @pytest.fixture(autouse=True)
+    def inject_client(self, api_client):
+        self.api_client = api_client
 
     def get_test_runs(
         self,
@@ -192,10 +196,13 @@ class TestFailuresGetTestRunsAPI:
         assert resp.status_code == 401
 
 
+@pytest.mark.usefixtures("api_client")
 class TestFailuresCheckTestRunAPI:
     fake = Faker()
-    api_app = create_app()
-    api_client = TestClient(api_app)
+
+    @pytest.fixture(autouse=True)
+    def inject_client(self, api_client):
+        self.api_client = api_client
 
     def get_test_run_check(
         self,

--- a/test/bases/terec/api/test_plots_api.py
+++ b/test/bases/terec/api/test_plots_api.py
@@ -1,14 +1,14 @@
+import pytest
+
 from faker import Faker
 from fastapi.testclient import TestClient
 
 from conftest import random_name
 from terec.api.auth import api_key_headers
 from terec.api.routers.results import TestSuiteInfo
-from terec.model.results import TestSuite
 from .random_data import (
     random_test_suite_run_info,
 )
-from terec.api.core import create_app
 
 
 def not_none(d: dict) -> dict:
@@ -20,10 +20,13 @@ def expect_error_404(api_client: TestClient, url: str) -> None:
     assert response.status_code == 404
 
 
+@pytest.mark.usefixtures("api_client")
 class TestPlotsAPI:
     fake = Faker()
-    api_app = create_app()
-    api_client = TestClient(api_app)
+
+    @pytest.fixture(autouse=True)
+    def inject_client(self, api_client):
+        self.api_client = api_client
 
     def get_history(self, org, project, suite, branch, headers=None):
         url = f"history/orgs/{org}/projects/{project}/suites/{suite}/builds?branch={branch}"

--- a/test/bases/terec/api/test_projects_api.py
+++ b/test/bases/terec/api/test_projects_api.py
@@ -1,8 +1,7 @@
 import json
+import pytest
 
 from faker import Faker
-from fastapi.testclient import TestClient
-from terec.api.core import create_app
 from terec.api.routers.projects import OrgInfo, is_valid_terec_name
 from terec.model.projects import Org, Project, OrgToken
 
@@ -11,10 +10,13 @@ def not_none(d: dict) -> dict:
     return {k: v for k, v in d.items() if v is not None}
 
 
+@pytest.mark.usefixtures("api_client")
 class TestGetOrgProjectsApi:
     fake = Faker()
-    api_app = create_app()
-    api_client = TestClient(api_app)
+
+    @pytest.fixture(autouse=True)
+    def inject_client(self, api_client):
+        self.api_client = api_client
 
     def test_should_raise_for_not_existing_org(self, cassandra_model):
         response = self.api_client.get("/admin/orgs/not-existing/projects")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ import time
 
 
 from cassandra.cluster import Session
-
+from fastapi.testclient import TestClient
 from loguru import logger
 
 from terec.database import cassandra_session
@@ -142,6 +142,14 @@ def public_project_suite_run(public_project_suite) -> TestSuiteRun:
         run_id=run_id,
     )
     return run
+
+
+@pytest.fixture(scope="session")
+def api_client() -> TestClient:
+    from terec.api.core import create_app
+
+    api_app = create_app()
+    return TestClient(api_app)
 
 
 def random_name(prefix: str) -> str:


### PR DESCRIPTION
This change aims at creating fastapi app only once in api tests:
- use fixture
- inject fixture as field